### PR TITLE
Update sitemap entries

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,30 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://qrnevjegy.hu/blog/1</loc>
+    <lastmod>2024-01-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://qrnevjegy.hu/blog/2</loc>
+    <lastmod>2024-01-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://qrnevjegy.hu/blog/3</loc>
+    <lastmod>2024-01-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://qrnevjegy.hu/blog/4</loc>
+    <lastmod>2024-01-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://qrnevjegy.hu/privacy</loc>
     <lastmod>2024-01-17</lastmod>
     <changefreq>monthly</changefreq>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -42,7 +42,7 @@ async function generateSitemap() {
     const sitemapXML = await streamToPromise(smStream);
 
     // Write the sitemap to the public directory
-    const writeStream = createWriteStream(resolve('dist', 'sitemap.xml'));
+    const writeStream = createWriteStream(resolve('public', 'sitemap.xml'));
     writeStream.write(sitemapXML.toString());
     writeStream.end();
 


### PR DESCRIPTION
## Summary
- output sitemap generation to `public` instead of `dist`
- include missing blog URLs in `public/sitemap.xml`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9a78d0c88320b3dc60e4adb23c6a